### PR TITLE
Use string match rather than expr with a regex

### DIFF
--- a/functions/balias.fish
+++ b/functions/balias.fish
@@ -1,6 +1,6 @@
 function balias --argument alias command
   eval 'alias $alias $command'
-  if expr $command : '^sudo '>/dev/null
+  if string match -q -r '^sudo ' $command
     set command (echo "$command" | cut -c6-)
   end
   complete -c $alias -xa "(


### PR DESCRIPTION
Not only is it faster, because `string` is a builtin, but it is actually portable now!

Fixes #7 